### PR TITLE
feat: custom types for VMAP offset and vast duration

### DIFF
--- a/vmap/structure.go
+++ b/vmap/structure.go
@@ -1,6 +1,12 @@
 package vmap
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
 
 type VMAP struct {
 	XMLName  xml.Name  `xml:"VMAP"`
@@ -15,7 +21,7 @@ type AdBreak struct {
 	TrackingEvents *[]TrackingEvent `xml:"TrackingEvents>Tracking"`
 	Id             string           `xml:"breakId,attr"`
 	BreakType      string           `xml:"breakType,attr"`
-	TimeOffset     string           `xml:"timeOffset,attr"`
+	TimeOffset     TimeOffset       `xml:"timeOffset,attr"`
 }
 
 type AdSource struct {
@@ -69,7 +75,7 @@ type Creative struct {
 type UniversalAdId struct{}
 
 type Linear struct {
-	Duration       string          `xml:"Duration"` // TODO: Make into duration object
+	Duration       Duration        `xml:"Duration"` // TODO: Make into duration object
 	TrackingEvents []TrackingEvent `xml:"TrackingEvents>Tracking"`
 	MediaFiles     []MediaFile     `xml:"MediaFiles>MediaFile"`
 	ClickThroughs  []ClickThrough  `xml:"VideoClicks>ClickThrough"`
@@ -100,4 +106,91 @@ type MediaFile struct {
 	Delivery  string `xml:"delivery,attr"`
 	MediaType string `xml:"type,attr"`
 	Codec     string `xml:"codec,attr"`
+}
+
+type Duration struct{ time.Duration }
+
+func (d *Duration) UnmarshalText(data []byte) error {
+	s := string(data)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		*d = Duration{}
+		return nil
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid duration format: %s", s)
+	}
+	// TODO: Figure this part out
+	hours, minutes, seconds := parts[0], parts[1], parts[2]
+	var sb strings.Builder
+	dur := time.Duration(0)
+	sb.WriteString(hours)
+	sb.WriteString("h")
+	sb.WriteString(minutes)
+	sb.WriteString("m")
+	// TODO: Handle seconds with decimal
+	if strings.Contains(seconds, ".") {
+		parts := strings.Split(seconds, ".")
+		sb.WriteString(parts[0])
+		sb.WriteString("s")
+		sb.WriteString(parts[1])
+		sb.WriteString("ms")
+	} else {
+		sb.WriteString(seconds)
+		sb.WriteString("s")
+	}
+	dur, err := time.ParseDuration(sb.String())
+	if err != nil {
+		return fmt.Errorf("error parsing duration: %w", err)
+	}
+	*d = Duration{dur}
+	return nil
+}
+
+// TimeOffset represents the time offset for an ad break in the VMAP document.
+type TimeOffset struct {
+	// If this is not nil, we're dealing with a duration offset.
+	Duration *Duration
+
+	//If not zero and duration is nil, it's a position number.
+	// -1 is reserved for start, -2 for end.
+	Position int
+
+	// If duration is nil and position is zero, this is a percentage offset.
+	Percent float32
+}
+
+const (
+	OffsetStart = -1
+	OffsetEnd   = -2
+)
+
+func (to *TimeOffset) UnmarshalText(data []byte) error {
+	switch string(data) {
+	case "start":
+		to.Position = OffsetStart
+	case "end":
+		to.Position = OffsetEnd
+
+	}
+	if strings.HasSuffix(string(data), "%") {
+		p, err := strconv.ParseInt(strings.TrimSuffix(string(data), "%"), 10, 8)
+		if err != nil {
+			return fmt.Errorf("error parsing percentage offset: %w", err)
+		}
+		to.Percent = float32(p) / 100
+		return nil
+	}
+	if strings.HasPrefix(string(data), "#") {
+		p, err := strconv.ParseInt(strings.TrimPrefix(string(data), "#"), 10, 8)
+		if err != nil {
+			return fmt.Errorf("error parsing position offset: %w", err)
+		}
+		to.Position = int(p)
+		return nil
+	}
+	var d Duration
+	to.Duration = &d
+	return to.Duration.UnmarshalText(data)
 }


### PR DESCRIPTION
- Add custom data type `TimeOffset`, meant to represent the time offset field in the VMAP spec.
- Add custom Duration type that can unmarshal VAST duration data
